### PR TITLE
Wrapping preBind notify call to UI handler

### DIFF
--- a/alfonz-adapter/src/main/java/org/alfonz/adapter/BaseDataBoundRecyclerAdapter.java
+++ b/alfonz-adapter/src/main/java/org/alfonz/adapter/BaseDataBoundRecyclerAdapter.java
@@ -62,11 +62,16 @@ public abstract class BaseDataBoundRecyclerAdapter<T extends ViewDataBinding> ex
 			if (mRecyclerView == null || mRecyclerView.isComputingLayout()) {
 				return true;
 			}
-			int childAdapterPosition = mRecyclerView.getChildAdapterPosition(binding.getRoot());
+			final int childAdapterPosition = mRecyclerView.getChildAdapterPosition(binding.getRoot());
 			if (childAdapterPosition == RecyclerView.NO_POSITION) {
 				return true;
 			}
-			notifyItemChanged(childAdapterPosition, DB_PAYLOAD);
+			mRecyclerView.post(new Runnable() {
+				@Override
+				public void run() {
+					notifyItemChanged(childAdapterPosition, DB_PAYLOAD);
+				}
+			});
 			return false;
 		}
 	};


### PR DESCRIPTION
This commit wraps the notifyItemChanged call in the
BaseDataBoundRecyclerAdapter with a View.post to ensure it is run by the
UI handler. This could be a reaction to a root cause in upstream code,
but worth doing anyway to be safe.